### PR TITLE
FIX: ZeroDivisionError when check same row/col

### DIFF
--- a/lib/panel.py
+++ b/lib/panel.py
@@ -162,7 +162,8 @@ class Panel:
 
 		# intersect
 		intersection_y = min(above.b, below.b) - below.y
-		return intersection_y / min(above.h(), below.h()) >= 1 / 3
+		min_h = min(above.h(), below.h())
+		return min_h == 0 or intersection_y / min_h >= 1 / 3
 
 	def same_col(self, other):
 		left, right = sorted([self, other], key = lambda p: p.x)
@@ -175,7 +176,8 @@ class Panel:
 
 		# intersect
 		intersection_x = min(left.r, right.r) - right.x
-		return intersection_x / min(left.w(), right.w()) >= 1 / 3
+		min_w =  min(left.w(), right.w())
+		return min_w == 0 or intersection_x / min_w >= 1 / 3
 
 	def find_top_panel(self):
 		all_top = list(filter(lambda p: p.b <= self.y and p.same_col(self), self.page.panels))

--- a/lib/segment.py
+++ b/lib/segment.py
@@ -191,5 +191,7 @@ class Segment:
 		p = np.array(p)
 		ap = p - a
 		ab = b - a
+		if ab[0] == 0 and ab[1] == 0:
+			return a
 		result = a + np.dot(ap, ab) / np.dot(ab, ab) * ab
 		return (round(result[0]), round(result[1]))


### PR DESCRIPTION
In the middle steps of generating panels, a line panel may be created(https://github.com/njean42/kumiko/issues/19 generated by `deoverlap_panels`). When the line panel participates in the calculations of `same_row` and `same_col`, it may result in a zero division error.